### PR TITLE
Fix spelling of encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ExPass
 
-A secure password hashing/encription library for node and JavaScript.
+A secure password hashing/encryption library for node and JavaScript.
 
 > **WARNING**: This document refers to the whole project, for specific node
 > implementation see the

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@expass/node",
   "version": "0.1.2-alpha.0",
-  "description": "A modern and secure password hashing/encription library for node",
+  "description": "A modern and secure password hashing/encryption library for node",
   "keywords": [
     "password",
     "hashing",
-    "encription",
+    "encryption",
     "security",
     "scrypt"
   ],


### PR DESCRIPTION
## Summary
- fix `encryption` spelling in README
- fix `encryption` spelling in `@expass/node` package.json

## Testing
- `npm test` *(fails: needed interactive lerna install)*

------
https://chatgpt.com/codex/tasks/task_e_6845364420488329a0e0bd8086a7009d