### PR TITLE
Fix verify example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const SECRET = 'Q6I1BIPZhTbd6G7XjVedePfUV3TllC';
     const encrypted = await expass.encode(password);
     // $expass$UUJpNU11MUxuNGd...
 
-    const isValid = await expass.compare(password, encrypted);
+    const isValid = await expass.verify(password, encrypted);
 )();
 ```
 


### PR DESCRIPTION
## Summary
- update README snippet to use `expass.verify` instead of `compare`

## Testing
- `npm test` *(fails: Cannot find module '@expass/core')*

------
https://chatgpt.com/codex/tasks/task_e_68453653363083298f5e97a34060b959