### PR TITLE
Add hash validation helper

### DIFF
--- a/packages/core/src/application/expass.spec.ts
+++ b/packages/core/src/application/expass.spec.ts
@@ -10,6 +10,8 @@ import { DefaultConfig } from './defaultconfig';
 import { Packager } from './packager';
 import { ExPass } from './expass';
 
+const valid = '$expass$v=1$fhuNdqUJe0hmYD7uGaAbmg$G2uVgUC0CnXoEy1lxs1BXuNd1sR9MDcP07b5.FxE1fGFMW7dDk_07eSEANZ.j5qX';
+
 describe('ExPass', () => {
     let container: typeof tsyContainer;
     let expass: ExPassInterface;
@@ -515,6 +517,16 @@ describe('ExPass', () => {
             )).rejects.toThrow('Encode block size is too high: 64');
         });
 
+    });
+
+    describe('#isExPassHash', () => {
+        it('Should return true for a valid hash', () => {
+            expect(expass.isExPassHash(valid)).toBe(true);
+        });
+
+        it('Should return false for an invalid hash', () => {
+            expect(expass.isExPassHash('invalid')).toBe(false);
+        });
     });
 
 });

--- a/packages/core/src/application/expass.ts
+++ b/packages/core/src/application/expass.ts
@@ -255,5 +255,14 @@ export class ExPass implements ExPassInterface {
         return this.crypto.secureCompare(encodedPassword, encodedSavedPassword);
     }
 
+    isExPassHash(hash: string): boolean {
+        try {
+            this.packager.unpack(hash);
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+
 }
 

--- a/packages/core/src/domain/expass.ts
+++ b/packages/core/src/domain/expass.ts
@@ -16,4 +16,5 @@ export interface ExPass {
     decrypt: (data: Buffer, keyAndIv: KeyAndIv, config: ExPassConfig) => Buffer;
     encode: (data: string, secret: Buffer, config: Partial<ExPassConfig>) => Promise<string>;
     compare: (data: string, hash: string, secret: Buffer, config: ExPassConfigParams) => Promise<boolean>;
+    isExPassHash: (hash: string) => boolean;
 }

--- a/packages/node/src/domain/nodeexpass.ts
+++ b/packages/node/src/domain/nodeexpass.ts
@@ -6,4 +6,5 @@ type ExPassConfigParams = interfaces.ExPassConfigParams;
 export interface NodeExPass {
     encode(password: string): Promise<string>;
     verify(password: string, hash: string): Promise<boolean>;
+    isExPassHash(hash: string): boolean;
 }

--- a/packages/node/src/infrastructure/nodeexpass.spec.ts
+++ b/packages/node/src/infrastructure/nodeexpass.spec.ts
@@ -71,4 +71,16 @@ describe('NodeExPass', () => {
 
     });
 
+    describe('#isExPassHash', () => {
+        it('Should return true for a valid hash', () => {
+            const exPass = new NodeExPass(secret);
+            expect(exPass.isExPassHash(valid)).toBe(true);
+        });
+
+        it('Should return false for an invalid hash', () => {
+            const exPass = new NodeExPass(secret);
+            expect(exPass.isExPassHash('invalid')).toBe(false);
+        });
+    });
+
 });

--- a/packages/node/src/infrastructure/nodeexpass.ts
+++ b/packages/node/src/infrastructure/nodeexpass.ts
@@ -98,4 +98,8 @@ export class NodeExPass implements NodeExPassInterface {
                 throw err;
             });
     }
+
+    isExPassHash(hash: string): boolean {
+        return this.#exPass.isExPassHash(hash);
+    }
 }

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "paths": {
+      "@expass/core": ["../core/src"]
+    },
     "outDir": "./lib",
     "rootDir": "./src",
     "composite": true


### PR DESCRIPTION
## Summary
- add `isExPassHash` to core `ExPass`
- expose validation method through node wrapper
- support paths to core sources from node package
- test new helper

## Testing
- `npx lerna run test --scope @expass/core`
- `npx lerna run test --scope @expass/node`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68453a04b49c832980855482137a5901